### PR TITLE
feat: scaffold sms consent placeholders

### DIFF
--- a/src/components/ConsentAdmin.tsx
+++ b/src/components/ConsentAdmin.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ConsentAdmin() {
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-bold">Consent Admin Dashboard</h2>
+      <p className="text-sm text-muted-foreground">TODO: Implement admin interface for managing consent records.</p>
+    </div>
+  );
+}

--- a/src/components/SMSAuth.tsx
+++ b/src/components/SMSAuth.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SMSAuth() {
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-bold">SMS Authentication</h2>
+      <p className="text-sm text-muted-foreground">TODO: Implement SMS authentication with consent integration.</p>
+    </div>
+  );
+}

--- a/src/components/SMSConsentForm.tsx
+++ b/src/components/SMSConsentForm.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SMSConsentForm() {
+  return (
+    <div className="border rounded p-4">
+      <h2 className="font-bold">SMS Consent Form</h2>
+      <p className="text-sm text-muted-foreground">TODO: Implement user-facing consent collection form.</p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,67 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 221.2 83.2% 53.3%;
+    --radius: 0.5rem;
+    --sidebar-background: var(--background);
+    --sidebar-foreground: var(--foreground);
+    --sidebar-primary: var(--primary);
+    --sidebar-primary-foreground: var(--primary-foreground);
+    --sidebar-accent: var(--accent);
+    --sidebar-accent-foreground: var(--accent-foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--ring);
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 217.2 91.2% 59.8%;
+    --radius: 0.5rem;
+    --sidebar-background: 222.2 47.4% 11.2%;
+    --sidebar-foreground: 210 40% 98%;
+    --sidebar-primary: 217.2 91.2% 59.8%;
+    --sidebar-primary-foreground: 210 40% 98%;
+    --sidebar-accent: 217.2 32.6% 17.5%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 217.2 32.6% 17.5%;
+    --sidebar-ring: 222.2 47.4% 11.2%;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import SMSConsentForm from './components/SMSConsentForm';
+import ConsentAdmin from './components/ConsentAdmin';
+import SMSAuth from './components/SMSAuth';
+
+function App() {
+  return (
+    <div className="p-4 space-y-4">
+      <SMSConsentForm />
+      <ConsentAdmin />
+      <SMSAuth />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add main React entry with Tailwind globals
- scaffold SMS consent, auth, and admin placeholders
- define Tailwind base styles and theme variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689e1e9882bc8326a0758d53b615a2be