### PR TITLE
Handle geolocation errors in media upload

### DIFF
--- a/src/components/InspectionForm.tsx
+++ b/src/components/InspectionForm.tsx
@@ -30,6 +30,7 @@ export default function InspectionForm() {
     { url: string; type: string; timestamp: number; coords?: { lat: number; lon: number } }[]
   >([]);
   const [online, setOnline] = useState<boolean>(navigator.onLine);
+  const [geoError, setGeoError] = useState<string | null>(null);
 
   // Load saved responses when property type changes
   useEffect(() => {
@@ -102,9 +103,13 @@ export default function InspectionForm() {
           lat: position.coords.latitude,
           lon: position.coords.longitude,
         };
-      } catch {
-        // ignore geolocation errors
+        setGeoError(null);
+      } catch (error) {
+        console.error('Geolocation error:', error);
+        setGeoError("Location data couldn't be retrieved");
       }
+    } else {
+      setGeoError("Location data couldn't be retrieved");
     }
     setMedia((m) => [...m, { url, type: file.type, timestamp, coords }]);
   };
@@ -178,6 +183,9 @@ export default function InspectionForm() {
           capture="environment"
           onChange={handleMediaChange}
         />
+        {geoError && (
+          <p className="text-sm text-red-600">{geoError}</p>
+        )}
         <ul className="text-sm list-disc pl-4">
           {media.map((m, i) => (
             <li key={i}>


### PR DESCRIPTION
## Summary
- Capture and log geolocation errors when attaching media in the inspection form
- Show an inline error message if location data cannot be retrieved

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a1095da5e8832692793aab4da29e59