### PR TITLE
feat: add SMS consent form

### DIFF
--- a/src/components/SMSConsentForm.tsx
+++ b/src/components/SMSConsentForm.tsx
@@ -1,10 +1,101 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function SMSConsentForm() {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [consent, setConsent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    if (!consent) {
+      setError('You must explicitly consent to receive SMS messages.');
+      return;
+    }
+
+    setLoading(true);
+    const record = {
+      name,
+      phone,
+      consent: true,
+      timestamp: new Date().toISOString(),
+    };
+
+    // Persist locally for audit trail
+    try {
+      const existing = JSON.parse(localStorage.getItem('sms_consent_records') || '[]');
+      existing.push(record);
+      localStorage.setItem('sms_consent_records', JSON.stringify(existing));
+    } catch {
+      // ignore localStorage errors
+    }
+
+    try {
+      const functionUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/save-sms-consent`;
+      const res = await fetch(functionUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        },
+        body: JSON.stringify({ name, phone, consent: true }),
+      });
+      if (!res.ok) {
+        throw new Error('Failed to save consent');
+      }
+      setSuccess('Consent recorded successfully.');
+      setName('');
+      setPhone('');
+      setConsent(false);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div className="border rounded p-4">
+    <div className="border rounded p-4 space-y-4 max-w-sm">
       <h2 className="font-bold">SMS Consent Form</h2>
-      <p className="text-sm text-muted-foreground">TODO: Implement user-facing consent collection form.</p>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="text"
+          placeholder="Full name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full border rounded p-2"
+          required
+        />
+        <input
+          type="tel"
+          placeholder="Phone number"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="w-full border rounded p-2"
+          required
+        />
+        <label className="flex items-center space-x-2 text-sm">
+          <input
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+          />
+          <span>I agree to receive SMS messages from Inspector Tools Pro.</span>
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          {loading ? 'Submitting...' : 'Submit'}
+        </button>
+      </form>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add user-facing SMS consent form
- persist consent to local storage and Supabase edge function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a113de6f7c832682e53b0f7d7fbe73