### PR TITLE
Validate phone numbers before SMS API calls

### DIFF
--- a/src/components/SMSAuth.tsx
+++ b/src/components/SMSAuth.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { supabase } from '@/lib/supabase';
+import { isValidPhone } from '@/lib/phone';
 
 export default function SMSAuth() {
   const [phone, setPhone] = useState('');
@@ -33,6 +34,10 @@ export default function SMSAuth() {
     setError(null);
     if (!consent) {
       setError('You must consent to receive SMS messages.');
+      return;
+    }
+    if (!isValidPhone(phone)) {
+      setError('Please enter a valid phone number in E.164 format.');
       return;
     }
     setLoading(true);

--- a/src/components/SMSConsentForm.tsx
+++ b/src/components/SMSConsentForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { isValidPhone } from '@/lib/phone';
 
 export default function SMSConsentForm() {
   const [name, setName] = useState('');
@@ -14,6 +15,11 @@ export default function SMSConsentForm() {
     setSuccess(null);
     if (!consent) {
       setError('You must explicitly consent to receive SMS messages.');
+      return;
+    }
+
+    if (!isValidPhone(phone)) {
+      setError('Please enter a valid phone number in E.164 format.');
       return;
     }
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,3 @@
+export function isValidPhone(phone: string): boolean {
+  return /^\+[1-9]\d{1,14}$/.test(phone);
+}


### PR DESCRIPTION
## Summary
- add E.164 phone validation helper
- ensure SMSAuth and SMSConsentForm validate phones before submission

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1186f39108326bee4f5da1cd33fb8