### PR TITLE
feat: validate Supabase config on init

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,25 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missingVars = [
+    !supabaseUrl && 'VITE_SUPABASE_URL',
+    !supabaseAnonKey && 'VITE_SUPABASE_ANON_KEY',
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  const message =
+    `Supabase configuration error: missing ${missingVars}. ` +
+    'Please set the required environment variables.';
+
+  if (typeof document !== 'undefined') {
+    document.body.innerHTML = `<p style="font-family: sans-serif;">${message}</p>`;
+  }
+
+  throw new Error(message);
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- check that `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are present before creating Supabase client
- show descriptive message and throw error when configuration is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a11875b5648326b072a9924444aae7