### PR TITLE
Add SMS component tests with React Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "build:gh-pages": "vite build --base=/inspector-tools/",
     "lint": "eslint .",
-    "test": "node --test",
+    "test": "vitest",
     "preview": "vite preview",
     "deploy": "npx gh-pages -d dist"
   },
@@ -86,6 +86,11 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vite-plugin-pwa": "^0.20.5"
+    "vite-plugin-pwa": "^0.20.5",
+    "vitest": "^2.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^23.0.0"
   }
 }

--- a/test/SMSAuth.test.tsx
+++ b/test/SMSAuth.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import SMSAuth from '@/components/SMSAuth';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithOtp: vi.fn(),
+      verifyOtp: vi.fn(),
+    },
+  },
+}));
+
+import { supabase } from '@/lib/supabase';
+
+describe('SMSAuth', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('handles happy path authentication flow', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockResolvedValue({ ok: true } as Response);
+    (supabase.auth.signInWithOtp as any).mockResolvedValue({ error: null });
+    (supabase.auth.verifyOtp as any).mockResolvedValue({ error: null });
+
+    render(<SMSAuth />);
+
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /send code/i }));
+
+    await screen.findByPlaceholderText('Enter code');
+
+    await user.type(screen.getByPlaceholderText('Enter code'), '123456');
+    await user.click(screen.getByRole('button', { name: /verify code/i }));
+
+    await screen.findByText('Phone number verified!');
+  });
+
+  it('validates consent before sending code', async () => {
+    const user = userEvent.setup();
+    render(<SMSAuth />);
+
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('button', { name: /send code/i }));
+
+    await screen.findByText('You must consent to receive SMS messages.');
+  });
+
+  it('shows error when sign in fails', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockResolvedValue({ ok: true } as Response);
+    (supabase.auth.signInWithOtp as any).mockResolvedValue({ error: { message: 'sign in failed' } });
+
+    render(<SMSAuth />);
+
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /send code/i }));
+
+    await screen.findByText('sign in failed');
+  });
+});

--- a/test/SMSConsentForm.test.tsx
+++ b/test/SMSConsentForm.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import SMSConsentForm from '@/components/SMSConsentForm';
+
+describe('SMSConsentForm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('submits consent successfully', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockResolvedValue({ ok: true } as Response);
+
+    render(<SMSConsentForm />);
+
+    await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await screen.findByText('Consent recorded successfully.');
+  });
+
+  it('requires explicit consent', async () => {
+    const user = userEvent.setup();
+    render(<SMSConsentForm />);
+
+    await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await screen.findByText('You must explicitly consent to receive SMS messages.');
+  });
+
+  it('shows error when request fails', async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockResolvedValue({ ok: false } as Response);
+
+    render(<SMSConsentForm />);
+
+    await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
+    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await screen.findByText('Failed to save consent');
+  });
+});

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,0 @@
-import assert from "node:assert";
-import test from "node:test";
-
-test("basic arithmetic", () => {
-  assert.strictEqual(1 + 1, 2);
-});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import { VitePWA } from 'vite-plugin-pwa';
 import path from "path";
@@ -114,5 +114,14 @@ export default defineConfig(({ mode }) => ({
     },
     sourcemap: false,
     minify: 'esbuild'
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './test/setup.ts',
+    env: {
+      VITE_SUPABASE_URL: 'https://example.com',
+      VITE_SUPABASE_ANON_KEY: 'anon-key'
+    }
   }
 }));


### PR DESCRIPTION
## Summary
- configure Vitest and React Testing Library
- add component tests for SMSAuth and SMSConsentForm
- mock Supabase auth and network requests in tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1187935088326b7bb43d5ba1b5793