### PR TITLE
feat: add optional auth bypass for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ npm install
 npm run dev
 ```
 
+#### Skipping SMS login during development
+
+Create a `.env` file and set `VITE_SKIP_AUTH=true` to bypass the SMS authentication flow and render the protected screens directly.
+
 ### Build
 ```bash
 npm run build        # Standard build

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import InspectionForm from './components/InspectionForm';
+import SMSAuth from './components/SMSAuth';
+import { supabase } from './lib/supabase';
+
+export default function App() {
+  const [authed, setAuthed] = useState(false);
+  const skipAuth = import.meta.env.VITE_SKIP_AUTH === 'true';
+
+  useEffect(() => {
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      setAuthed(!!data.session);
+    };
+    init();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setAuthed(!!session);
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (skipAuth || authed) {
+    return (
+      <div className="p-4">
+        <InspectionForm />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <SMSAuth />
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import InspectionForm from './components/InspectionForm';
-
-function App() {
-  return (
-    <div className="p-4">
-      <InspectionForm />
-    </div>
-  );
-}
+import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add App component with optional VITE_SKIP_AUTH to bypass SMS login
- wire main entry to new App component
- document auth bypass flag in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1082ef9e48326af121becfd52a536