### PR TITLE
Add bilingual prompts and language-aware recording

### DIFF
--- a/src/components/InspectionForm.tsx
+++ b/src/components/InspectionForm.tsx
@@ -21,22 +21,46 @@ interface SpeechRecognition {
   stop: () => void;
 }
 
-const propertyPrompts: Record<string, string[]> = {
-  single: [
-    'Check exterior doors',
-    'Inspect windows for damage',
-    'Review roof and gutters',
-  ],
-  condo: [
-    'Inspect entryway and lobby',
-    'Check balcony safety',
-    'Test appliances',
-  ],
-  commercial: [
-    'Check signage and lighting',
-    'Inspect parking area',
-    'Review HVAC system',
-  ],
+const propertyPrompts: Record<
+  string,
+  Record<'en' | 'es', string[]>
+> = {
+  single: {
+    en: [
+      'Check exterior doors',
+      'Inspect windows for damage',
+      'Review roof and gutters',
+    ],
+    es: [
+      'Verificar las puertas exteriores',
+      'Inspeccionar ventanas por daños',
+      'Revisar techo y canaletas',
+    ],
+  },
+  condo: {
+    en: [
+      'Inspect entryway and lobby',
+      'Check balcony safety',
+      'Test appliances',
+    ],
+    es: [
+      'Inspeccionar entrada y vestíbulo',
+      'Comprobar seguridad del balcón',
+      'Probar electrodomésticos',
+    ],
+  },
+  commercial: {
+    en: [
+      'Check signage and lighting',
+      'Inspect parking area',
+      'Review HVAC system',
+    ],
+    es: [
+      'Revisar señalización e iluminación',
+      'Inspeccionar área de estacionamiento',
+      'Revisar sistema HVAC',
+    ],
+  },
 };
 
 const STORAGE_KEY_PREFIX = 'inspection-';
@@ -84,6 +108,13 @@ export default function InspectionForm() {
       window.removeEventListener('offline', handleOnline);
     };
   }, []);
+
+  // Update recognition language when switching languages
+  useEffect(() => {
+    if (recognitionRef.current) {
+      recognitionRef.current.lang = language;
+    }
+  }, [language]);
 
   const startRecording = (prompt: string) => {
     const SpeechRecognition =
@@ -159,7 +190,8 @@ export default function InspectionForm() {
     };
   }, []);
 
-  const prompts = propertyPrompts[propertyType];
+  const langKey = language.startsWith('es') ? 'es' : 'en';
+  const prompts = propertyPrompts[propertyType][langKey];
 
   return (
     <div className="space-y-4">

--- a/test/InspectionForm.test.tsx
+++ b/test/InspectionForm.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import InspectionForm from '@/components/InspectionForm';
+
+describe('InspectionForm language switching', () => {
+  it('updates prompts and recognition language based on selected language', async () => {
+    const user = userEvent.setup();
+
+    class MockRecognition {
+      lang = '';
+      interimResults = false;
+      maxAlternatives = 1;
+      onresult: ((event: any) => void) | null = null;
+      onend: (() => void) | null = null;
+      start = vi.fn();
+      stop = vi.fn();
+    }
+    let lastInstance: MockRecognition | null = null;
+    const recognitionMock = vi.fn(() => {
+      lastInstance = new MockRecognition();
+      return lastInstance;
+    });
+    (window as any).SpeechRecognition = recognitionMock;
+    (window as any).webkitSpeechRecognition = recognitionMock;
+
+    render(<InspectionForm />);
+
+    // Start recording in default English
+    await user.click(screen.getAllByRole('button', { name: /speak/i })[0]);
+    expect(lastInstance?.lang).toBe('en-US');
+
+    // Switch to Spanish
+    await user.selectOptions(screen.getByLabelText(/language/i), 'es-ES');
+
+    // Prompts should be in Spanish
+    expect(
+      screen.getByText('Verificar las puertas exteriores')
+    ).toBeInTheDocument();
+
+    // Recognition language should update
+    expect(lastInstance?.lang).toBe('es-ES');
+  });
+});


### PR DESCRIPTION
## Summary
- Provide English and Spanish prompts for each property type
- Use selected language for prompt display and speech recognition
- Add test verifying prompts and speech recognition update when switching languages

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a808046bc48326b78a27d8e4e622a9