### PR TITLE
test: use E.164 numbers in SMS flows

### DIFF
--- a/test/SMSAuth.test.tsx
+++ b/test/SMSAuth.test.tsx
@@ -27,7 +27,7 @@ describe('SMSAuth', () => {
 
     render(<SMSAuth />);
 
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('checkbox'));
     await user.click(screen.getByRole('button', { name: /send code/i }));
 
@@ -43,7 +43,7 @@ describe('SMSAuth', () => {
     const user = userEvent.setup();
     render(<SMSAuth />);
 
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('button', { name: /send code/i }));
 
     await screen.findByText('You must consent to receive SMS messages.');
@@ -56,7 +56,7 @@ describe('SMSAuth', () => {
 
     render(<SMSAuth />);
 
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('checkbox'));
     await user.click(screen.getByRole('button', { name: /send code/i }));
 

--- a/test/SMSConsentForm.test.tsx
+++ b/test/SMSConsentForm.test.tsx
@@ -16,7 +16,7 @@ describe('SMSConsentForm', () => {
     render(<SMSConsentForm />);
 
     await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('checkbox'));
     await user.click(screen.getByRole('button', { name: /submit/i }));
 
@@ -28,7 +28,7 @@ describe('SMSConsentForm', () => {
     render(<SMSConsentForm />);
 
     await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('button', { name: /submit/i }));
 
     await screen.findByText('You must explicitly consent to receive SMS messages.');
@@ -41,7 +41,7 @@ describe('SMSConsentForm', () => {
     render(<SMSConsentForm />);
 
     await user.type(screen.getByPlaceholderText('Full name'), 'John Doe');
-    await user.type(screen.getByPlaceholderText('Phone number'), '1234567890');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+15551234567');
     await user.click(screen.getByRole('checkbox'));
     await user.click(screen.getByRole('button', { name: /submit/i }));
 


### PR DESCRIPTION
## Summary
- use E.164 phone numbers for SMSAuth tests
- use E.164 phone numbers for SMSConsentForm tests

## Testing
- `npm test -- --run` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden from registry.npmjs.org/@testing-library/jest-dom)*


------
https://chatgpt.com/codex/tasks/task_e_68a80952e0f48326ae8158adf11888d2