### PR TITLE
Refactor tests and client portal

### DIFF
--- a/src/components/ClientPortal.tsx
+++ b/src/components/ClientPortal.tsx
@@ -1,15 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
-
 import PayInvoiceButton from './PayInvoiceButton';
 
-
-codex/continue-implementation-of-feature-nvnmmi
-import PayInvoiceButton from './PayInvoiceButton';
-
-import PayInvoiceButton from './PayInvoiceButton';
-
-main
 type Report = {
   id: string;
   title: string;
@@ -18,19 +10,9 @@ type Report = {
 export default function ClientPortal() {
   const [reports, setReports] = useState<Report[]>([]);
   const [error, setError] = useState<string | null>(null);
-
   const [query, setQuery] = useState('');
   const paymentsEnabled = import.meta.env.VITE_PAYMENTS_ENABLED === 'true';
 
-
-codex/continue-implementation-of-feature-nvnmmi
-  const [query, setQuery] = useState('');
-  const paymentsEnabled = import.meta.env.VITE_PAYMENTS_ENABLED === 'true';
-
-  const [query, setQuery] = useState('');
-  const paymentsEnabled = import.meta.env.VITE_PAYMENTS_ENABLED === 'true';
-
-main
   useEffect(() => {
     const load = async () => {
       const { data: userData } = await supabase.auth.getUser();
@@ -51,10 +33,6 @@ main
     return <p className="text-red-600">{error}</p>;
   }
 
-codex/continue-implementation-of-feature-nvnmmi
-
-codex/continue-implementation-of-feature-7okmdd
- main
   const filtered = reports.filter((r) =>
     r.title.toLowerCase().includes(query.toLowerCase())
   );
@@ -78,26 +56,9 @@ codex/continue-implementation-of-feature-7okmdd
         ))}
       </ul>
       <p className="text-xs text-gray-600 mt-6">
-        Inspection reports are provided for informational purposes only and do not
-        constitute legal or financial advice.
+        Inspection reports are provided for informational purposes only and do
+        not constitute legal or financial advice.
       </p>
-
-codex/continue-implementation-of-feature-nvnmmi
-  return (
-    <div className="p-4">
-      <h2 className="font-bold mb-2">My Reports</h2>
-      <ul className="list-disc pl-6">
-        {reports.map((r) => (
-codex/continue-implementation-of-feature-sphc6g
-          <li key={r.id} className="mb-2">
-            <div>{r.title}</div>
-            {paymentsEnabled && <PayInvoiceButton reportId={r.id} />}
-          </li>
-          <li key={r.id}>{r.title}</li>
-main
-        ))}
-      </ul>
-main
     </div>
   );
 }

--- a/src/offline/queue.ts
+++ b/src/offline/queue.ts
@@ -1,0 +1,18 @@
+export interface UploadItem {
+  id: string;
+  file: File;
+  meta?: any;
+}
+
+const uploads: UploadItem[] = [];
+
+export async function enqueueUpload(item: UploadItem) {
+  uploads.push(item);
+}
+
+export async function flushQueue(handler: (item: UploadItem) => Promise<void>) {
+  while (uploads.length) {
+    const item = uploads.shift()!;
+    await handler(item);
+  }
+}

--- a/test/ClientPortal.test.tsx
+++ b/test/ClientPortal.test.tsx
@@ -1,14 +1,5 @@
 import { render, screen } from '@testing-library/react';
-codex/continue-implementation-of-feature-xdvitk
 import userEvent from '@testing-library/user-event';
-
-import userEvent from '@testing-library/user-event';
-
-codex/continue-implementation-of-feature-7okmdd
-import userEvent from '@testing-library/user-event';
-main
-main
-main
 import { vi } from 'vitest';
 import ClientPortal from '@/components/ClientPortal';
 import { supabase } from '@/lib/supabase';
@@ -23,13 +14,6 @@ vi.mock('@/lib/supabase', () => ({
 function mockReports(data = [{ id: '1', title: 'Report A' }]) {
   (supabase.auth.getUser as any).mockResolvedValue({ data: { user: { id: '123' } } });
   const eq = vi.fn().mockResolvedValue({ data, error: null });
-codex/continue-implementation-of-feature-xdvitk
-
-function mockReports() {
-  (supabase.auth.getUser as any).mockResolvedValue({ data: { user: { id: '123' } } });
-  const eq = vi.fn().mockResolvedValue({ data: [{ id: '1', title: 'Report A' }], error: null });
-main
-main
   const select = vi.fn().mockReturnValue({ eq });
   (supabase.from as any).mockReturnValue({ select });
 }
@@ -82,7 +66,4 @@ describe('ClientPortal UX', () => {
       )
     ).toBeInTheDocument();
   });
-codex/continue-implementation-of-feature-xdvitk
 });
-});
-main

--- a/test/InspectionForm.test.tsx
+++ b/test/InspectionForm.test.tsx
@@ -212,7 +212,5 @@ describe('InspectionForm features', () => {
     await user.click(screen.getByLabelText(/enable voice input/i));
     expect(screen.getAllByRole('button', { name: /speak/i })).toHaveLength(3);
   });
-codex/continue-implementation-of-feature-xdvitk
 
-main
 });

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -21,21 +21,14 @@ vi.mock('idb-keyval', () => {
 
 import * as idbKeyval from 'idb-keyval';
 
-codex/continue-implementation-of-feature-xdvitk
-main
 // Preserve any existing implementations so we can restore them after tests
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
 
-codex/continue-implementation-of-feature-xdvitk
-main
-main
 beforeEach(() => {
   (idbKeyval as any)._store.clear();
 });
 
-codex/continue-implementation-of-feature-xdvitk
-main
 beforeAll(() => {
   // jsdom doesn't implement these APIs, so provide lightweight mocks
   Object.defineProperty(global.URL, 'createObjectURL', {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig(({ mode }) => ({
           },
           {
             src: 'icon-512.png',
-            sizes: '512x512', 
+            sizes: '512x512',
             type: 'image/png',
             purpose: 'any maskable'
           }
@@ -108,29 +108,20 @@ export default defineConfig(({ mode }) => ({
         manualChunks: {
           vendor: ['react', 'react-dom'],
           ui: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu'],
-          utils: ['date-fns', 'clsx', 'tailwind-merge']
-        }
-      }
+          utils: ['date-fns', 'clsx', 'tailwind-merge'],
+        },
+      },
     },
     sourcemap: false,
-    minify: 'esbuild'
-codex/continue-implementation-of-feature-xdvitk
+    minify: 'esbuild',
   },
   test: {
     environment: 'jsdom',
     globals: true,
     setupFiles: ['test/setupTests.ts'],
-    setupFiles: ['test/setupTests.ts'],
-
-    setupFiles: ['test/setupTests.ts'],
-
-  setupFiles: './test/setupTests.ts',
-
-main
     env: {
       VITE_SUPABASE_URL: 'https://example.com',
       VITE_SUPABASE_ANON_KEY: 'anon-key'
     }
-main
   }
 }));


### PR DESCRIPTION
## Summary
- strip accidental codex markers from client portal and tests
- add simple offline upload queue stub
- mock URL.createObjectURL in tests to fix environment

## Testing
- `npm test` *(fails: Test Files 1 failed | 4 passed | 1 skipped (7))*

------
https://chatgpt.com/codex/tasks/task_e_68b0a93d72408326962b118192bbd2d5