### PR TITLE
What I changed

### DIFF
--- a/scripts/test-functions.ps1
+++ b/scripts/test-functions.ps1
@@ -35,11 +35,11 @@ function Resolve-Config {
   if ($cfg.Url -and $cfg.Anon) { return $cfg }
 
   # Try env files relative to script
-  $root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+  $root = (Resolve-Path -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
   $envFiles = @(
-    Join-Path $root '.env.local',
-    Join-Path $root 'env.local',
-    Join-Path $root '.env'
+    (Join-Path -Path $root -ChildPath '.env.local')
+    (Join-Path -Path $root -ChildPath 'env.local')
+    (Join-Path -Path $root -ChildPath '.env')
   )
   foreach ($f in $envFiles) {
     $map = Read-EnvFromFile -Path $f


### PR DESCRIPTION
scripts/test-functions.ps1
Correctly builds the list of env files using Join-Path with explicit parameter names and proper array construction, avoiding accidental arrays passed to parameters. How to run now

From repo root:
pwsh scripts/test-functions.ps1 -Action save-consent Or from the scripts folder:
pwsh ./test-functions.ps1 -Action save-consent