### PR TITLE
ESLint config:

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,19 @@ try {
       },
     }
   );
+  // Test and functions overrides
+  config.push(
+    {
+      files: [
+        "test/**/*.{ts,tsx}",
+        "**/*.test.{ts,tsx}",
+        "supabase/functions/**/*.ts",
+      ],
+      rules: {
+        "@typescript-eslint/no-explicit-any": "off",
+      },
+    }
+  );
 } catch {
   config = [
     {

--- a/src/components/ConsentAdmin.tsx
+++ b/src/components/ConsentAdmin.tsx
@@ -121,7 +121,7 @@ export default function ConsentAdmin() {
         />
         <select
           value={status}
-          onChange={(e) => setStatus(e.target.value as any)}
+          onChange={(e) => setStatus(e.target.value as 'all' | 'active' | 'revoked')}
           className="border rounded px-2 py-1"
         >
           <option value="all">All</option>

--- a/src/offline/queue.ts
+++ b/src/offline/queue.ts
@@ -1,7 +1,7 @@
 export interface UploadItem {
   id: string;
   file: File;
-  meta?: any;
+  meta?: Record<string, unknown>;
 }
 
 const uploads: UploadItem[] = [];

--- a/supabase/functions/create-payment-session/index.ts
+++ b/supabase/functions/create-payment-session/index.ts
@@ -6,13 +6,14 @@ import { serve } from "https://deno.land/std@0.195.0/http/server.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
-  let body: any;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return json({ error: "Invalid JSON" }, 400);
   }
-  const reportId = typeof body?.reportId === "string" ? body.reportId : null;
+  const b = body as Record<string, unknown>;
+  const reportId = typeof b?.reportId === "string" ? (b.reportId as string) : null;
   if (!reportId) return json({ error: "reportId is required" }, 400);
 
   // Stubbed checkout URL for local/dev testing
@@ -26,4 +27,3 @@ function json(data: unknown, status = 200) {
     headers: { "Content-Type": "application/json" },
   });
 }
-

--- a/supabase/functions/export-consent-data/index.ts
+++ b/supabase/functions/export-consent-data/index.ts
@@ -36,7 +36,7 @@ serve(async (req) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const role = (userData.user.user_metadata as any)?.role;
+  const role = (userData.user.user_metadata as { role?: string } | null | undefined)?.role;
   if (role !== "admin") {
     return new Response("Forbidden", { status: 403 });
   }

--- a/supabase/functions/save-sms-consent/index.ts
+++ b/supabase/functions/save-sms-consent/index.ts
@@ -22,16 +22,17 @@ serve(async (req) => {
     return new Response("Method Not Allowed", { status: 405 });
   }
 
-  let body: any;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return json({ error: "Invalid JSON" }, 400);
   }
 
-  const name = typeof body?.name === "string" ? body.name : null;
-  const phone = body?.phone;
-  const consent = body?.consent;
+  const b = body as Record<string, unknown>;
+  const name = typeof b?.name === "string" ? (b.name as string) : null;
+  const phone = b?.phone as string | undefined;
+  const consent = b?.consent as boolean | undefined;
 
   if (typeof phone !== "string" || !/^\+[1-9]\d{1,14}$/.test(phone)) {
     return json({ error: "Invalid phone (E.164 required)" }, 400);

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -64,11 +64,11 @@ beforeAll(() => {
       continuous = true;
       interimResults = true;
       lang = 'en-US';
-      onresult: ((event: any) => void) | null = null;
+      onresult: ((event: unknown) => void) | null = null;
       onend: (() => void) | null = null;
       start = vi.fn();
       stop = vi.fn(() => this.onend && this.onend());
-    } as unknown as typeof (window as any).SpeechRecognition;
+    } as unknown as new () => SpeechRecognition;
   };
   if (!(window as any).SpeechRecognition) {
     Object.defineProperty(window as any, 'SpeechRecognition', {


### PR DESCRIPTION
eslint.config.js: added overrides to allow any in tests and Edge Functions only, keeping app code strict. Test setup parse error:
test/setupTests.ts: replaced tricky class cast with a simpler constructor type and removed any, fixing “Identifier expected”. App code type fixes:
src/components/InspectionForm.tsx:
Typed SpeechRecognition constructor properly; removed any casts. Typed dynamic import of offline queue without any; removed empty catch; narrowed meta typing when reading values. recognitionRef now useRef<SpeechRecognition | null>(null). src/components/ConsentAdmin.tsx: removed as any by narrowing to 'all' | 'active' | 'revoked'. src/offline/queue.ts: meta?: Record<string, unknown> instead of any. src/lib/formQueue.ts: fully generic queue API (no any). Edge Functions type cleanups:
supabase/functions/save-sms-consent/index.ts: unknown body → narrowed via Record. supabase/functions/export-consent-data/index.ts: typed user_metadata shape. supabase/functions/create-payment-session/index.ts: unknown body → narrowed via Record.